### PR TITLE
change naming (next_to_a_beeper -> on_beeper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ right_is_clear(), right_is_blocked(),
 
 back_is_clear(), back_is_blocked(),
 
-next_to_a_beeper(), not_next_to_a_beeper(),
+on_beeper(), not_on_beeper(),
 
 any_beepers_in_beeper_bag(), no_beepers_in_beeper_bag(),
 

--- a/karel.py
+++ b/karel.py
@@ -104,14 +104,14 @@ class Karel(object):
         return not self.back_is_clear()
 
     # conditions(about beepers)
-    def next_to_a_beeper(self):
+    def on_beeper(self):
         if (self._x, self._y) in self.parent.beepers_dict:
             return True
         else:
             return False
 
-    def not_next_to_a_beeper(self):
-        return not self.next_to_a_beeper()
+    def not_on_beeper(self):
+        return not self.on_beeper()
 
     def any_beepers_in_beeper_bag(self):
         if self._beeper_bag == 0:


### PR DESCRIPTION
next_to_a_beeper라 표현했을 때 beeper가 현재 로봇의 칸에 있는 것을 뜻하는 것인지 로봇의 주변 칸에 있는 것인지가 명확하지 않아 on_beeper로 수정.